### PR TITLE
gl context creation options

### DIFF
--- a/binding/binding.cc
+++ b/binding/binding.cc
@@ -26,7 +26,8 @@ namespace nodejsgl {
 static napi_value CreateWebGLRenderingContext(napi_env env,
                                               napi_callback_info info) {
   napi_value instance;
-  napi_status nstatus = WebGLRenderingContext::NewInstance(env, &instance, info);
+  napi_status nstatus =
+      WebGLRenderingContext::NewInstance(env, &instance, info);
   ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
 
   return instance;

--- a/binding/binding.cc
+++ b/binding/binding.cc
@@ -26,7 +26,7 @@ namespace nodejsgl {
 static napi_value CreateWebGLRenderingContext(napi_env env,
                                               napi_callback_info info) {
   napi_value instance;
-  napi_status nstatus = WebGLRenderingContext::NewInstance(env, &instance);
+  napi_status nstatus = WebGLRenderingContext::NewInstance(env, &instance, info);
   ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
 
   return instance;

--- a/binding/egl_context_wrapper.cc
+++ b/binding/egl_context_wrapper.cc
@@ -151,7 +151,8 @@ void EGLContextWrapper::InitEGL(napi_env env,
     return;
   }
 
-  EGLint surface_attribs[] = {EGL_WIDTH, (EGLint)context_options.width, EGL_HEIGHT, (EGLint)context_options.height,
+  EGLint surface_attribs[] = {EGL_WIDTH, (EGLint)context_options.width,
+                              EGL_HEIGHT, (EGLint)context_options.height,
                               EGL_NONE};
   surface = eglCreatePbufferSurface(display, config, surface_attribs);
   if (surface == EGL_NO_SURFACE) {

--- a/binding/egl_context_wrapper.cc
+++ b/binding/egl_context_wrapper.cc
@@ -151,7 +151,7 @@ void EGLContextWrapper::InitEGL(napi_env env,
     return;
   }
 
-  EGLint surface_attribs[] = {EGL_WIDTH, (EGLint)1, EGL_HEIGHT, (EGLint)1,
+  EGLint surface_attribs[] = {EGL_WIDTH, (EGLint)context_options.width, EGL_HEIGHT, (EGLint)context_options.height,
                               EGL_NONE};
   surface = eglCreatePbufferSurface(display, config, surface_attribs);
   if (surface == EGL_NO_SURFACE) {

--- a/binding/egl_context_wrapper.h
+++ b/binding/egl_context_wrapper.h
@@ -37,8 +37,10 @@ namespace nodejsgl {
 // Provides initialization of EGL/GL context options.
 struct GLContextOptions {
   bool webgl_compatibility = false;
-  int client_major_es_version = 3;
-  int client_minor_es_version = 0;
+  uint32_t client_major_es_version = 3;
+  uint32_t client_minor_es_version = 0;
+  uint32_t width = 1;
+  uint32_t height = 1;
 };
 
 // Provides lookup of EGL/GL extensions.

--- a/binding/webgl_rendering_context.cc
+++ b/binding/webgl_rendering_context.cc
@@ -375,7 +375,8 @@ static napi_status GetArrayLikeBuffer(napi_env env, napi_value array_like_value,
 
 napi_ref WebGLRenderingContext::constructor_ref_;
 
-WebGLRenderingContext::WebGLRenderingContext(napi_env env, GLContextOptions opts)
+WebGLRenderingContext::WebGLRenderingContext(napi_env env,
+                                             GLContextOptions opts)
     : env_(env), ref_(nullptr) {
   eglContextWrapper_ = EGLContextWrapper::Create(env, opts);
   if (!eglContextWrapper_) {

--- a/binding/webgl_rendering_context.h
+++ b/binding/webgl_rendering_context.h
@@ -29,10 +29,11 @@ namespace nodejsgl {
 class WebGLRenderingContext {
  public:
   static napi_status Register(napi_env env, napi_value exports);
-  static napi_status NewInstance(napi_env env, napi_value* instance);
+  static napi_status NewInstance(napi_env env, napi_value* instance, 
+                                               napi_callback_info info);
 
  private:
-  WebGLRenderingContext(napi_env env);
+  WebGLRenderingContext(napi_env env, GLContextOptions opts);
   ~WebGLRenderingContext();
 
   static napi_value InitInternal(napi_env env, napi_callback_info info);

--- a/binding/webgl_rendering_context.h
+++ b/binding/webgl_rendering_context.h
@@ -29,8 +29,8 @@ namespace nodejsgl {
 class WebGLRenderingContext {
  public:
   static napi_status Register(napi_env env, napi_value exports);
-  static napi_status NewInstance(napi_env env, napi_value* instance, 
-                                               napi_callback_info info);
+  static napi_status NewInstance(napi_env env, napi_value* instance,
+                                 napi_callback_info info);
 
  private:
   WebGLRenderingContext(napi_env env, GLContextOptions opts);

--- a/src/binding.d.ts
+++ b/src/binding.d.ts
@@ -16,5 +16,11 @@
  */
 
 export interface NodeJsGlBinding {
-  createWebGLRenderingContext(): WebGLRenderingContext|WebGL2RenderingContext;
+  createWebGLRenderingContext(
+    width: number, 
+    height: number,
+    client_major_es_version: number,
+    client_minor_es_version: number,
+    webgl_compatbility: boolean
+    ): WebGLRenderingContext | WebGL2RenderingContext;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,4 +21,31 @@ import {NodeJsGlBinding} from './binding';
 
 const binding = bindings('nodejs_gl_binding') as NodeJsGlBinding;
 
-export {binding};
+
+interface ContextArguments {
+    width?: number,
+    height?: number,
+    webGLCompability?: boolean,
+    majorVersion?: number,
+    minorVersion?: number,
+};
+
+const createWebGLRenderingContext = function(args: ContextArguments = {}) {
+    const width =  args.width || 1;
+    const height = args.height || 1;
+    const webGLCompability = args.webGLCompability || false;
+    const majorVersion =  args.majorVersion || 3;
+    const minorVersion =  args.minorVersion || 0;
+    return binding.createWebGLRenderingContext(
+        width,
+        height,
+        majorVersion,
+        minorVersion,
+        webGLCompability,
+    );
+
+
+} 
+
+
+export { createWebGLRenderingContext };

--- a/src/tests/float_texture_upload_test.ts
+++ b/src/tests/float_texture_upload_test.ts
@@ -2,7 +2,7 @@ import * as gles from '../.';
 
 import {createTexture2D, ensureFramebufferAttachment, initEnvGL} from './test_utils';
 
-const gl = gles.binding.createWebGLRenderingContext();
+const gl = gles.createWebGLRenderingContext({});
 const gl2 = gl as WebGL2RenderingContext;
 
 gl.getExtension('OES_texture_float');

--- a/src/tests/half_float_texture_upload_test.ts
+++ b/src/tests/half_float_texture_upload_test.ts
@@ -2,7 +2,7 @@ import * as gles from '../.';
 
 import {createTexture2D, ensureFramebufferAttachment, initEnvGL} from './test_utils';
 
-const gl = gles.binding.createWebGLRenderingContext();
+const gl = gles.createWebGLRenderingContext();
 
 console.log('VERSION: ' + gl.getParameter(gl.VERSION));
 console.log('RENDERER: ' + gl.getParameter(gl.RENDERER));

--- a/src/tests/old_texture_test.ts
+++ b/src/tests/old_texture_test.ts
@@ -1,6 +1,6 @@
 import * as gles from '../.';
 
-const gl = gles.binding.createWebGLRenderingContext();
+const gl = gles.createWebGLRenderingContext();
 const gl2 = gl as WebGL2RenderingContext;
 gl.viewport(0, 0, 1, 1);
 

--- a/src/tests/unsigned_byte_texture_upload_test.ts
+++ b/src/tests/unsigned_byte_texture_upload_test.ts
@@ -2,7 +2,7 @@ import * as gles from '../.';
 
 import {createTexture2D, ensureFramebufferAttachment, initEnvGL} from './test_utils';
 
-const gl = gles.binding.createWebGLRenderingContext();
+const gl = gles.createWebGLRenderingContext();
 
 console.log('VERSION: ' + gl.getParameter(gl.VERSION));
 console.log('RENDERER: ' + gl.getParameter(gl.RENDERER));


### PR DESCRIPTION
Initialize the context in node by doing 
```JavaScript
const gl = nodeGles.createWebGLRenderingContext({
  width: 256,
  height: 256,
  majorVersion: 3,
  minorVersion: 0,
  webGLCompability: true
});
```
It's a bit of a hastle sending the arguments through several functions, but I couldn't think of any better way to do it. 

This would be a breaking change as it drops the `binding` attribute since the `createWebGLRenderingContext` function now takes an interface (and doesn't return the binding). This could however be easily dodged by just adding a `binding variable, but that seems like bad practise.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/node-gles/53)
<!-- Reviewable:end -->
