### PR TITLE
Uniform call fixes

### DIFF
--- a/binding/webgl_rendering_context.cc
+++ b/binding/webgl_rendering_context.cc
@@ -68,6 +68,20 @@ class ArrayLikeBuffer {
     }
   }
 
+  size_t size() {
+    switch (array_type) {
+      case kInt32:
+        return length / sizeof(int32_t);
+      case kFloat32:
+        return length / sizeof(float);
+      default:
+        fprintf(
+            stderr,
+            "WARNING: Cannot determine size of unknown array buffer type\n");
+        return 0;
+    }
+  }
+
   void *data;
   size_t length;
   bool should_delete;
@@ -4498,9 +4512,9 @@ napi_value WebGLRenderingContext::Uniform1iv(napi_env env,
   nstatus = UnwrapContext(env, js_this, &context);
   ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
 
-  context->eglContextWrapper_->glUniform1iv(location,
-                                            static_cast<GLsizei>(alb.length),
-                                            static_cast<GLint *>(alb.data));
+  context->eglContextWrapper_->glUniform1iv(
+      location, static_cast<GLsizei>(alb.size()),
+      static_cast<GLint *>(alb.data));
 
 #if DEBUG
   context->CheckForErrors();
@@ -4572,7 +4586,7 @@ napi_value WebGLRenderingContext::Uniform1fv(napi_env env,
   ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
 
   context->eglContextWrapper_->glUniform1fv(
-      location, alb.length, reinterpret_cast<GLfloat *>(alb.data));
+      location, alb.size(), reinterpret_cast<GLfloat *>(alb.data));
 
 #if DEBUG
   context->CheckForErrors();
@@ -4649,9 +4663,9 @@ napi_value WebGLRenderingContext::Uniform2fv(napi_env env,
   nstatus = UnwrapContext(env, js_this, &context);
   ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
 
-  context->eglContextWrapper_->glUniform2fv(location,
-                                            static_cast<GLsizei>(alb.length),
-                                            static_cast<GLfloat *>(alb.data));
+  context->eglContextWrapper_->glUniform2fv(
+      location, static_cast<GLsizei>(alb.size() >> 1),
+      static_cast<GLfloat *>(alb.data));
 
 #if DEBUG
   context->CheckForErrors();
@@ -4706,7 +4720,8 @@ napi_value WebGLRenderingContext::Uniform2iv(napi_env env,
   ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
 
   context->eglContextWrapper_->glUniform2iv(
-      location, 1, reinterpret_cast<GLint *>(alb.data));
+      location, static_cast<GLsizei>(alb.size() >> 1),
+      reinterpret_cast<GLint *>(alb.data));
 
 #if DEBUG
   context->CheckForErrors();
@@ -4760,7 +4775,8 @@ napi_value WebGLRenderingContext::Uniform3iv(napi_env env,
   ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
 
   context->eglContextWrapper_->glUniform3iv(
-      location, 1, reinterpret_cast<GLint *>(alb.data));
+      location, static_cast<GLsizei>(alb.size() / 3),
+      reinterpret_cast<GLint *>(alb.data));
 
 #if DEBUG
   context->CheckForErrors();
@@ -4844,7 +4860,7 @@ napi_value WebGLRenderingContext::Uniform3fv(napi_env env,
   ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
 
   context->eglContextWrapper_->glUniform3fv(
-      location, static_cast<GLsizei>(alb.length),
+      location, static_cast<GLsizei>(alb.size() / 3),
       reinterpret_cast<GLfloat *>(alb.data));
 
 #if DEBUG
@@ -4881,7 +4897,7 @@ napi_value WebGLRenderingContext::Uniform4fv(napi_env env,
   ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
 
   context->eglContextWrapper_->glUniform4fv(
-      location, static_cast<GLsizei>(alb.length),
+      location, static_cast<GLsizei>(alb.size() >> 2),
       reinterpret_cast<GLfloat *>(alb.data));
 
 #if DEBUG
@@ -4937,9 +4953,9 @@ napi_value WebGLRenderingContext::Uniform4iv(napi_env env,
   nstatus = UnwrapContext(env, js_this, &context);
   ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
 
-  context->eglContextWrapper_->glUniform4iv(location,
-                                            static_cast<GLsizei>(alb.length),
-                                            static_cast<GLint *>(alb.data));
+  context->eglContextWrapper_->glUniform4iv(
+      location, static_cast<GLsizei>(alb.size() >> 2),
+      static_cast<GLint *>(alb.data));
 
 #if DEBUG
   context->CheckForErrors();
@@ -5033,7 +5049,7 @@ napi_value WebGLRenderingContext::UniformMatrix2fv(napi_env env,
   ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
 
   context->eglContextWrapper_->glUniformMatrix2fv(
-      location, static_cast<GLsizei>(alb.length),
+      location, static_cast<GLsizei>(alb.size() >> 2),
       static_cast<GLboolean>(transpose),
       static_cast<const GLfloat *>(alb.data));
 
@@ -5076,7 +5092,7 @@ napi_value WebGLRenderingContext::UniformMatrix3fv(napi_env env,
   ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
 
   context->eglContextWrapper_->glUniformMatrix3fv(
-      location, static_cast<GLsizei>(alb.length),
+      location, static_cast<GLsizei>(alb.size() / 9),
       static_cast<GLboolean>(transpose),
       static_cast<const GLfloat *>(alb.data));
 
@@ -5119,7 +5135,7 @@ napi_value WebGLRenderingContext::UniformMatrix4fv(napi_env env,
   ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
 
   context->eglContextWrapper_->glUniformMatrix4fv(
-      location, static_cast<GLsizei>(alb.length),
+      location, static_cast<GLsizei>(alb.size() >> 4),
       static_cast<GLboolean>(transpose),
       static_cast<const GLfloat *>(alb.data));
 

--- a/binding/webgl_rendering_context.cc
+++ b/binding/webgl_rendering_context.cc
@@ -4512,9 +4512,9 @@ napi_value WebGLRenderingContext::Uniform1iv(napi_env env,
   nstatus = UnwrapContext(env, js_this, &context);
   ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
 
-  context->eglContextWrapper_->glUniform1iv(
-      location, static_cast<GLsizei>(alb.size()),
-      static_cast<GLint *>(alb.data));
+  context->eglContextWrapper_->glUniform1iv(location,
+                                            static_cast<GLsizei>(alb.size()),
+                                            static_cast<GLint *>(alb.data));
 
 #if DEBUG
   context->CheckForErrors();

--- a/binding/webgl_rendering_context.cc
+++ b/binding/webgl_rendering_context.cc
@@ -4923,6 +4923,8 @@ napi_value WebGLRenderingContext::Uniform4iv(napi_env env,
   ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
   ENSURE_ARGC_RETVAL(env, argc, 2, nullptr);
 
+  ENSURE_VALUE_IS_NUMBER_RETVAL(env, args[0], nullptr);
+
   GLint location;
   nstatus = napi_get_value_int32(env, args[0], &location);
   ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
@@ -4961,6 +4963,12 @@ napi_value WebGLRenderingContext::Uniform4f(napi_env env,
   WebGLRenderingContext *context = nullptr;
   nstatus = UnwrapContext(env, js_this, &context);
   ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
+
+  ENSURE_VALUE_IS_NUMBER_RETVAL(env, args[0], nullptr);
+  ENSURE_VALUE_IS_NUMBER_RETVAL(env, args[1], nullptr);
+  ENSURE_VALUE_IS_NUMBER_RETVAL(env, args[2], nullptr);
+  ENSURE_VALUE_IS_NUMBER_RETVAL(env, args[3], nullptr);
+  ENSURE_VALUE_IS_NUMBER_RETVAL(env, args[4], nullptr);
 
   GLint location;
   nstatus = napi_get_value_int32(env, args[0], &location);


### PR DESCRIPTION
The main issue is that the value being passed to the `count` parameter for `glUniform*v` calls is the (byte) length of the `ArrayLikeBuffer` instead of the number of uniform variables (vectors/matrices). This can cause crashes when calling those functions.

Doc references:
https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUniform.xhtml
https://www.khronos.org/opengl/wiki/GLSL_:_common_mistakes#How_to_use_glUniform

In order to determine the number of elements in an ALB, `size()` was added. Right now it just uses a switch statement to match the destructor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/node-gles/56)
<!-- Reviewable:end -->
