### PR TITLE
Don't throw for unsupported extensions

### DIFF
--- a/binding/webgl_rendering_context.cc
+++ b/binding/webgl_rendering_context.cc
@@ -2551,9 +2551,8 @@ napi_value WebGLRenderingContext::GetExtension(napi_env env,
     nstatus =
         WebGLLoseContextExtension::NewInstance(env, &webgl_extension, egl_ctx);
   } else {
-    fprintf(stderr, "Extension: %s\n", name);
-    NAPI_THROW_ERROR(env, "Unsupported extension");
-    nstatus = napi_invalid_arg;
+    fprintf(stderr, "Unsupported extension: %s\n", name);
+    nstatus = napi_get_null(env, &webgl_extension);
   }
   ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
 


### PR DESCRIPTION
In WebGL, calls to `getExtension` return null if an extension isn't supported. The current throw behavior can cause issues for e.g. libraries that aren't expecting this to happen.

Spec: https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.14

This change no longer throws an error and instead returns null for unsupported extensions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/node-gles/57)
<!-- Reviewable:end -->
