### PR TITLE
Fix log buffer size and free it after use

### DIFF
--- a/binding/webgl_rendering_context.cc
+++ b/binding/webgl_rendering_context.cc
@@ -3149,12 +3149,13 @@ napi_value WebGLRenderingContext::GetProgramInfoLog(napi_env env,
   context->eglContextWrapper_->glGetProgramiv(program, GL_INFO_LOG_LENGTH,
                                               &log_length);
 
-  char *error = new char[log_length + 1];
-  context->eglContextWrapper_->glGetProgramInfoLog(program, log_length + 1,
+  char *error = new char[log_length];
+  context->eglContextWrapper_->glGetProgramInfoLog(program, log_length,
                                                    &log_length, error);
 
   napi_value error_value;
-  nstatus = napi_create_string_utf8(env, error, log_length + 1, &error_value);
+  nstatus = napi_create_string_utf8(env, error, log_length, &error_value);
+  delete[] error;
   ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
 
 #if DEBUG
@@ -3277,12 +3278,13 @@ napi_value WebGLRenderingContext::GetShaderInfoLog(napi_env env,
   context->eglContextWrapper_->glGetShaderiv(shader, GL_INFO_LOG_LENGTH,
                                              &log_length);
 
-  char *error = new char[log_length + 1];
-  context->eglContextWrapper_->glGetShaderInfoLog(shader, log_length + 1,
+  char *error = new char[log_length];
+  context->eglContextWrapper_->glGetShaderInfoLog(shader, log_length,
                                                   &log_length, error);
 
   napi_value error_value;
-  nstatus = napi_create_string_utf8(env, error, log_length + 1, &error_value);
+  nstatus = napi_create_string_utf8(env, error, log_length, &error_value);
+  delete[] error;
   ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
 
 #if DEBUG


### PR DESCRIPTION
The `+ 1` isn't needed as the length provided by `glGetProgramiv` includes the null terminator. The length expected by `napi_create_string_utf8` is just the string length (without the null terminator), which is set by `glGetProgramInfoLog`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/node-gles/58)
<!-- Reviewable:end -->
