### PR TITLE
Unpackpixels

### DIFF
--- a/binding/webgl_rendering_context.cc
+++ b/binding/webgl_rendering_context.cc
@@ -404,10 +404,10 @@ WebGLRenderingContext::WebGLRenderingContext(napi_env env,
   }
   alloc_count_ = 0;
 
-  unpack_alignment = false;
+  unpack_alignment = 4;
   unpack_colorspace_conversion = false;
   unpack_flip_y = false;
-  unpack_premultiply_alpha = false;
+  unpack_premultiply_alpha = 0x9244;
 }
 
 WebGLRenderingContext::~WebGLRenderingContext() {

--- a/binding/webgl_rendering_context.h
+++ b/binding/webgl_rendering_context.h
@@ -197,8 +197,8 @@ class WebGLRenderingContext {
 
   std::atomic<size_t> alloc_count_;
   // WebGL specific
-  size_t unpack_alignment;
-  size_t unpack_colorspace_conversion;
+  GLint unpack_alignment;
+  GLint unpack_colorspace_conversion;
   bool unpack_flip_y;
   bool unpack_premultiply_alpha;
   unsigned char* unpackPixels(GLenum type, GLenum format, GLint width,

--- a/binding/webgl_rendering_context.h
+++ b/binding/webgl_rendering_context.h
@@ -196,6 +196,13 @@ class WebGLRenderingContext {
   EGLContextWrapper* eglContextWrapper_;
 
   std::atomic<size_t> alloc_count_;
+  // WebGL specific
+  size_t unpack_alignment;
+  size_t unpack_colorspace_conversion;
+  bool unpack_flip_y;
+  bool unpack_premultiply_alpha;
+  unsigned char* unpackPixels(GLenum type, GLenum format, GLint width,
+                              GLint height, unsigned char* pixels);
 };
 
 }  // namespace nodejsgl


### PR DESCRIPTION
Don't merge this yet (!)

This adds some of the missing functionality for unpacking. It's ported from the stackgl/headless-gl repo, and I'm unsure of how that affects licensing.

Also the current implementation needs a memory clean-up, since it allocates a new image, but I'm unsure of how that would work with the current implementation with the ArrayLikeBuffer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/node-gles/65)
<!-- Reviewable:end -->
