### PR TITLE
Add all common parameters to context definition and make gl.getParameter support.

### DIFF
--- a/binding/binding.cc
+++ b/binding/binding.cc
@@ -51,6 +51,7 @@ static napi_value InitBinding(napi_env env, napi_value exports) {
   WebGLDebugRendererInfoExtension::Register(env, exports);
   WebGLDepthTextureExtension::Register(env, exports);
   WebGLLoseContextExtension::Register(env, exports);
+  WebGLDrawBuffersExtension::Register(env, exports);
   WebGLRenderingContext::Register(env, exports);
 
   napi_property_descriptor properties[] = {

--- a/binding/egl_context_wrapper.cc
+++ b/binding/egl_context_wrapper.cc
@@ -444,6 +444,10 @@ void EGLContextWrapper::BindProcAddresses() {
   // ANGLE specific
   glRequestExtensionANGLE = reinterpret_cast<PFNGLREQUESTEXTENSIONANGLEPROC>(
       eglGetProcAddress("glRequestExtensionANGLE"));
+
+  // GL ES
+  glGetFloatv =
+      reinterpret_cast<PFNGLGETFLOATVPROC>(eglGetProcAddress("glGetFloatv"));
 }
 
 void EGLContextWrapper::RefreshGLExtensions() {

--- a/binding/egl_context_wrapper.h
+++ b/binding/egl_context_wrapper.h
@@ -233,6 +233,9 @@ class EGLContextWrapper {
   // ANGLE specific
   PFNGLREQUESTEXTENSIONANGLEPROC glRequestExtensionANGLE;
 
+  // GL ES
+  PFNGLGETFLOATVPROC glGetFloatv;
+
   // Refreshes extensions list:
   void RefreshGLExtensions();
 

--- a/binding/webgl_extensions.cc
+++ b/binding/webgl_extensions.cc
@@ -936,4 +936,56 @@ napi_value WebGLLoseContextExtension::RestoreContext(napi_env env,
   return nullptr;
 }
 
+//==============================================================================
+// WebGLDrawBuffersExtension
+
+napi_ref WebGLDrawBuffersExtension::constructor_ref_;
+
+WebGLDrawBuffersExtension::WebGLDrawBuffersExtension(napi_env env)
+    : GLExtensionBase(env) {}
+
+/* static */
+bool WebGLDrawBuffersExtension::IsSupported(
+    EGLContextWrapper* egl_context_wrapper) {
+  IS_EXTENSION_NAME_AVAILABLE("GL_EXT_draw_buffers");
+}
+
+/* static */
+napi_status WebGLDrawBuffersExtension::Register(napi_env env,
+                                                napi_value exports) {
+  napi_status nstatus;
+
+  napi_property_descriptor properties[] = {
+      NapiDefineIntProperty(env, GL_MAX_COLOR_ATTACHMENTS,
+                            "MAX_COLOR_ATTACHMENTS_WEBGL"),
+      NapiDefineIntProperty(env, GL_MAX_DRAW_BUFFERS, "MAX_DRAW_BUFFERS_WEBGL"),
+  };
+
+  napi_value ctor_value;
+  nstatus = napi_define_class(env, "WEBGL_draw_buffers", NAPI_AUTO_LENGTH,
+                              GLExtensionBase::InitStubClass, nullptr,
+                              ARRAY_SIZE(properties), properties, &ctor_value);
+  ENSURE_NAPI_OK_RETVAL(env, nstatus, nstatus);
+
+  nstatus = napi_create_reference(env, ctor_value, 1, &constructor_ref_);
+  ENSURE_NAPI_OK_RETVAL(env, nstatus, nstatus);
+
+  return napi_ok;
+}
+
+/* static */
+napi_status WebGLDrawBuffersExtension::NewInstance(
+    napi_env env, napi_value* instance,
+    EGLContextWrapper* egl_context_wrapper) {
+  ENSURE_EXTENSION_IS_SUPPORTED
+
+  napi_status nstatus = NewInstanceBase(env, constructor_ref_, instance);
+  ENSURE_NAPI_OK_RETVAL(env, nstatus, nstatus);
+
+  egl_context_wrapper->glRequestExtensionANGLE("GL_EXT_draw_buffers");
+  egl_context_wrapper->RefreshGLExtensions();
+
+  return napi_ok;
+}
+
 }  // namespace nodejsgl

--- a/binding/webgl_extensions.h
+++ b/binding/webgl_extensions.h
@@ -239,6 +239,16 @@ class WebGLLoseContextExtension : public GLExtensionBase {
   static void Cleanup(napi_env env, void* native, void* hint);
 };
 
+// Provides 'WEBGL_draw_buffers':
+// https://www.khronos.org/registry/webgl/extensions/WEBGL_draw_buffers/
+class WebGLDrawBuffersExtension : public GLExtensionBase {
+  NAPI_BOOTSTRAP_METHODS
+
+ protected:
+  WebGLDrawBuffersExtension(napi_env env);
+  virtual ~WebGLDrawBuffersExtension() {}
+};
+
 }  // namespace nodejsgl
 
 #endif  // NODEJS_GL_WEBGL_EXTENSIONS_H_

--- a/binding/webgl_rendering_context.cc
+++ b/binding/webgl_rendering_context.cc
@@ -960,6 +960,55 @@ napi_status WebGLRenderingContext::Register(napi_env env, napi_value exports) {
       NapiDefineIntProperty(env, GL_RED, "RED"),
       NapiDefineIntProperty(env, GL_SYNC_GPU_COMMANDS_COMPLETE,
                             "SYNC_GPU_COMMANDS_COMPLETE"),
+      NapiDefineIntProperty(env, GL_MAX_VERTEX_UNIFORM_COMPONENTS,
+                            "MAX_VERTEX_UNIFORM_COMPONENTS"),
+      NapiDefineIntProperty(env, GL_MAX_VERTEX_UNIFORM_BLOCKS,
+                            "MAX_VERTEX_UNIFORM_BLOCKS"),
+      NapiDefineIntProperty(env, GL_MAX_VERTEX_OUTPUT_COMPONENTS,
+                            "MAX_VERTEX_OUTPUT_COMPONENTS"),
+      NapiDefineIntProperty(env, GL_MAX_VARYING_COMPONENTS,
+                            "MAX_VARYING_COMPONENTS"),
+      NapiDefineIntProperty(env, GL_MAX_FRAGMENT_UNIFORM_COMPONENTS,
+                            "MAX_FRAGMENT_UNIFORM_COMPONENTS"),
+      NapiDefineIntProperty(env, GL_MAX_FRAGMENT_UNIFORM_BLOCKS,
+                            "MAX_FRAGMENT_UNIFORM_BLOCKS"),
+      NapiDefineIntProperty(env, GL_MAX_FRAGMENT_INPUT_COMPONENTS,
+                            "MAX_FRAGMENT_INPUT_COMPONENTS"),
+      NapiDefineIntProperty(env, GL_MIN_PROGRAM_TEXEL_OFFSET,
+                            "MIN_PROGRAM_TEXEL_OFFSET"),
+      NapiDefineIntProperty(env, GL_MAX_PROGRAM_TEXEL_OFFSET,
+                            "MAX_PROGRAM_TEXEL_OFFSET"),
+      NapiDefineIntProperty(env, GL_MAX_DRAW_BUFFERS, "MAX_DRAW_BUFFERS"),
+      NapiDefineIntProperty(env, GL_MAX_COLOR_ATTACHMENTS,
+                            "MAX_COLOR_ATTACHMENTS"),
+      NapiDefineIntProperty(env, GL_MAX_SAMPLES, "MAX_SAMPLES"),
+      NapiDefineIntProperty(env, GL_MAX_3D_TEXTURE_SIZE, "MAX_3D_TEXTURE_SIZE"),
+      NapiDefineIntProperty(env, GL_MAX_ARRAY_TEXTURE_LAYERS,
+                            "MAX_ARRAY_TEXTURE_LAYERS"),
+      NapiDefineIntProperty(env, GL_MAX_TEXTURE_LOD_BIAS,
+                            "MAX_TEXTURE_LOD_BIAS"),
+      NapiDefineIntProperty(env, GL_MAX_UNIFORM_BUFFER_BINDINGS,
+                            "MAX_UNIFORM_BUFFER_BINDINGS"),
+      NapiDefineIntProperty(env, GL_MAX_UNIFORM_BLOCK_SIZE,
+                            "MAX_UNIFORM_BLOCK_SIZE"),
+      NapiDefineIntProperty(env, GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT,
+                            "UNIFORM_BUFFER_OFFSET_ALIGNMENT"),
+      NapiDefineIntProperty(env, GL_MAX_COMBINED_UNIFORM_BLOCKS,
+                            "MAX_COMBINED_UNIFORM_BLOCKS"),
+      NapiDefineIntProperty(env, GL_MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS,
+                            "MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS"),
+      NapiDefineIntProperty(env, GL_MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS,
+                            "MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS"),
+      NapiDefineIntProperty(env,
+                            GL_MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS,
+                            "MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS"),
+      NapiDefineIntProperty(env, GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS,
+                            "MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS"),
+      NapiDefineIntProperty(env, GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS,
+                            "MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS"),
+      NapiDefineIntProperty(env, GL_MAX_ELEMENT_INDEX, "MAX_ELEMENT_INDEX"),
+      NapiDefineIntProperty(env, GL_MAX_SERVER_WAIT_TIMEOUT,
+                            "MAX_SERVER_WAIT_TIMEOUT"),
   };
 
   // Create constructor
@@ -2555,6 +2604,10 @@ napi_value WebGLRenderingContext::GetExtension(napi_env env,
              WebGLLoseContextExtension::IsSupported(egl_ctx)) {
     nstatus =
         WebGLLoseContextExtension::NewInstance(env, &webgl_extension, egl_ctx);
+  } else if (strcmp(name, "WEBGL_draw_buffers") == 0 &&
+             WebGLDrawBuffersExtension::IsSupported(egl_ctx)) {
+    nstatus =
+        WebGLDrawBuffersExtension::NewInstance(env, &webgl_extension, egl_ctx);
   } else {
     fprintf(stderr, "Unsupported extension: %s\n", name);
     nstatus = napi_get_null(env, &webgl_extension);
@@ -2579,6 +2632,41 @@ napi_value WebGLRenderingContext::GetParameter(napi_env env,
   ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
 
   switch (name) {
+    // Int32
+    case GL_MAX_DRAW_BUFFERS:
+    case GL_MAX_RENDERBUFFER_SIZE:
+    case GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT:
+    case GL_MAX_VERTEX_UNIFORM_COMPONENTS:
+    case GL_MAX_VERTEX_UNIFORM_BLOCKS:
+    case GL_MAX_VERTEX_OUTPUT_COMPONENTS:
+    case GL_MAX_VARYING_COMPONENTS:
+    case GL_MAX_FRAGMENT_UNIFORM_COMPONENTS:
+    case GL_MAX_FRAGMENT_UNIFORM_BLOCKS:
+    case GL_MAX_FRAGMENT_INPUT_COMPONENTS:
+    case GL_MIN_PROGRAM_TEXEL_OFFSET:
+    case GL_MAX_PROGRAM_TEXEL_OFFSET:
+    case GL_MAX_COLOR_ATTACHMENTS:
+    case GL_MAX_SAMPLES:
+    case GL_MAX_3D_TEXTURE_SIZE:
+    case GL_MAX_ARRAY_TEXTURE_LAYERS:
+    case GL_MAX_TEXTURE_LOD_BIAS:
+    case GL_MAX_UNIFORM_BUFFER_BINDINGS:
+    case GL_MAX_UNIFORM_BLOCK_SIZE:
+    case GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT:
+    case GL_MAX_COMBINED_UNIFORM_BLOCKS:
+    case GL_MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS:
+    case GL_MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS:
+    case GL_MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS:
+    case GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS:
+    case GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS:
+    case GL_MAX_ELEMENT_INDEX:
+    case GL_MAX_SERVER_WAIT_TIMEOUT:
+    case GL_RED_BITS:
+    case GL_GREEN_BITS:
+    case GL_BLUE_BITS:
+    case GL_ALPHA_BITS:
+    case GL_DEPTH_BITS:
+    case GL_STENCIL_BITS:
     case GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS:
     case GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS:
     case GL_MAX_CUBE_MAP_TEXTURE_SIZE:
@@ -2587,7 +2675,7 @@ napi_value WebGLRenderingContext::GetParameter(napi_env env,
     case GL_MAX_VARYING_VECTORS:
     case GL_MAX_FRAGMENT_UNIFORM_VECTORS:
     case GL_MAX_TEXTURE_SIZE:
-    case GL_MAX_TEXTURE_IMAGE_UNITS:
+    case GL_MAX_TEXTURE_IMAGE_UNITS: {
       GLint params;
       context->eglContextWrapper_->glGetIntegerv(name, &params);
 
@@ -2596,7 +2684,12 @@ napi_value WebGLRenderingContext::GetParameter(napi_env env,
       ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
 
       return params_value;
+    }
 
+    // String
+    case GL_SHADING_LANGUAGE_VERSION:
+    case GL_VENDOR:
+    case GL_RENDERER:
     case GL_VERSION: {
       const GLubyte *str = context->eglContextWrapper_->glGetString(name);
       if (str) {
@@ -2623,18 +2716,53 @@ napi_value WebGLRenderingContext::GetParameter(napi_env env,
       return previous_buffer_value;
     }
 
-    case GL_RENDERER: {
-      const GLubyte *str = context->eglContextWrapper_->glGetString(name);
-      if (str) {
-        const char *str_c_str = reinterpret_cast<const char *>(str);
-        napi_value str_value;
-        nstatus = napi_create_string_utf8(env, str_c_str, strlen(str_c_str),
-                                          &str_value);
-        ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
+    // Int32Array
+    case GL_MAX_VIEWPORT_DIMS: {
+      int length = 2;
 
-        return str_value;
-      }
-      break;
+      GLint values[4] = {0};
+      context->eglContextWrapper_->glGetIntegerv(name, values);
+
+      size_t byte_length = sizeof(GLint) * length;
+
+      napi_value arraybuffer;
+      void *arraybuffer_data = nullptr;
+      nstatus = napi_create_arraybuffer(env, byte_length, &arraybuffer_data,
+                                        &arraybuffer);
+      ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
+      memcpy(arraybuffer_data, values, byte_length);
+
+      napi_value int32array;
+      nstatus = napi_create_typedarray(env, napi_int32_array, length,
+                                       arraybuffer, 0, &int32array);
+      ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
+
+      return int32array;
+    }
+
+    // Float32Array
+    case GL_ALIASED_POINT_SIZE_RANGE:
+    case GL_ALIASED_LINE_WIDTH_RANGE: {
+      int length = 2;
+
+      GLfloat values[4] = {0};
+      context->eglContextWrapper_->glGetFloatv(name, values);
+
+      size_t byte_length = sizeof(GLfloat) * length;
+
+      napi_value arraybuffer;
+      void *arraybuffer_data = nullptr;
+      nstatus = napi_create_arraybuffer(env, byte_length, &arraybuffer_data,
+                                        &arraybuffer);
+      ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
+      memcpy(arraybuffer_data, values, byte_length);
+
+      napi_value float32array;
+      nstatus = napi_create_typedarray(env, napi_float32_array, length,
+                                       arraybuffer, 0, &float32array);
+      ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
+
+      return float32array;
     }
 
       // TODO(kreeger): Add more of these
@@ -3136,7 +3264,7 @@ napi_value WebGLRenderingContext::GetContextAttributes(
                                     stencil_value);
   ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
 
-  return stencil_value;
+  return context_attr_value;
 }
 
 /* static */


### PR DESCRIPTION
feat(webgl_rendering_context): Add all common parameters to context definition, make method gl.getParameter support int32array and float32array return value.
fix(webgl_rendering_context): Fix the return value of method gl.getContextAttributes.
feat(webgl_extensions): Add WEBGL_draw_buffers extension.
feat(egl_context_wrapper): Add method glGetFloatv to get float parameter value(s).